### PR TITLE
Add javadoc lint task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 
-[*.{gradle,java}]
+[*.{gradle,java,mapping}]
 indent_style = tab
 ij_continuation_indent_size = 8
 ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.fabricmc.**

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
 	implementation "org.ow2.asm:asm:$project.asm_version"
 	implementation "org.ow2.asm:asm-tree:$project.asm_version"
+	implementation "cuchaz:enigma:$project.enigma_version"
 }
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	implementation "org.ow2.asm:asm:$project.asm_version"
 	implementation "org.ow2.asm:asm-tree:$project.asm_version"
 	implementation "cuchaz:enigma:$project.enigma_version"
+
+	testImplementation platform("org.junit:junit-bom:$project.junit_version")
+	testImplementation 'org.junit.jupiter:junit-jupiter'
+	testImplementation "org.assertj:assertj-core:$project.assertj_version"
 }
 
 gradlePlugin {
@@ -46,6 +50,10 @@ gradlePlugin {
 			implementationClass = 'net.fabricmc.filament.FilamentGradlePlugin'
 		}
 	}
+}
+
+test {
+	useJUnitPlatform()
 }
 
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 def ENV = System.getenv()
 
 group = 'net.fabricmc'
-version = '0.1.0' + (ENV.GITHUB_ACTIONS ? "" : "+local")
+version = '0.2.0' + (ENV.GITHUB_ACTIONS ? "" : "+local")
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_11
@@ -62,12 +62,6 @@ checkstyle {
 }
 
 publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			from components.java
-		}
-	}
-
 	repositories {
 		if (ENV.MAVEN_URL) {
 			repositories.maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 asm_version = 9.1
 enigma_version = 0.27.0
+junit_version = 5.7.1
+assertj_version = 3.19.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 asm_version = 9.1
-enigma_version = 0.27.0
+enigma_version = 0.27.1
 junit_version = 5.7.1
 assertj_version = 3.19.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 asm_version = 9.1
+enigma_version = 0.27.0

--- a/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
+++ b/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
@@ -4,10 +4,12 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import net.fabricmc.filament.task.GeneratePackageInfoMappingsTask;
+import net.fabricmc.filament.task.JavadocLintTask;
 
 public final class FilamentGradlePlugin implements Plugin<Project> {
 	@Override
 	public void apply(Project project) {
 		project.getTasks().register("generatePackageInfoMappings", GeneratePackageInfoMappingsTask.class);
+		project.getTasks().register("javadocLint", JavadocLintTask.class);
 	}
 }

--- a/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
+++ b/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
@@ -1,0 +1,112 @@
+package net.fabricmc.filament.task;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.serde.MappingFileNameFormat;
+import cuchaz.enigma.translation.mapping.serde.MappingParseException;
+import cuchaz.enigma.translation.mapping.serde.MappingSaveParameters;
+import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsReader;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+public class JavadocLintTask extends DefaultTask {
+	private static final Pattern PARAM_DOC_START = Pattern.compile("^@param\\s+");
+	private static final Pattern TYPE_PARAM_DOC_START = Pattern.compile("^@param\\s+<");
+	private final DirectoryProperty mappingDirectory = getProject().getObjects().directoryProperty();
+
+	@InputDirectory
+	public DirectoryProperty getMappingDirectory() {
+		return mappingDirectory;
+	}
+
+	public JavadocLintTask() {
+		// Ignore outputs for up-to-date checks as there aren't any (so only inputs are checked)
+		getOutputs().upToDateWhen(task -> true);
+	}
+
+	@TaskAction
+	public void run() throws IOException, MappingParseException {
+		var saveParameters = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
+		Path directory = mappingDirectory.getAsFile().get().toPath();
+		EntryTree<EntryMapping> mappings = EnigmaMappingsReader.DIRECTORY.read(directory, ProgressListener.none(), saveParameters);
+		List<String> errors = new ArrayList<>();
+
+		mappings.getAllEntries().parallel().forEach(entry -> {
+			EntryMapping mapping = mappings.get(entry);
+			String javadoc = mapping.getJavadoc();
+
+			if (javadoc != null && !javadoc.isEmpty()) {
+				List<String> localErrors = new ArrayList<>();
+
+				if (entry instanceof LocalVariableEntry && ((LocalVariableEntry) entry).isArgument()) {
+					if (javadoc.endsWith(".")) {
+						localErrors.add("parameter javadoc ends with '.'");
+					}
+
+					if (Character.isUpperCase(javadoc.charAt(0))) {
+						String word = getFirstWord(javadoc);
+
+						// ignore single-letter "words" (like X or Z)
+						if (word.length() > 1) {
+							localErrors.add("parameter javadoc starts with uppercase word '" + word + "'");
+						}
+					}
+				} else if (entry instanceof MethodEntry) {
+					if (javadoc.lines().anyMatch(JavadocLintTask::isRegularMethodParameter)) {
+						localErrors.add("method contains parameter docs, which should be on the parameter itself");
+					}
+				}
+
+				// new rules can be added here in the future
+
+				if (!localErrors.isEmpty()) {
+					String name = getFullName(mappings, entry);
+
+					for (String error : localErrors) {
+						errors.add(name + ": " + error);
+					}
+				}
+			}
+		});
+
+		if (!errors.isEmpty()) {
+			for (String error : errors) {
+				getLogger().error("lint: {}", error);
+			}
+
+			throw new GradleException("Found " + errors.size() + " javadoc format errors! See the log for details.");
+		}
+	}
+
+	private static boolean isRegularMethodParameter(String line) {
+		return PARAM_DOC_START.matcher(line).matches() && !TYPE_PARAM_DOC_START.matcher(line).matches();
+	}
+
+	private static String getFirstWord(String str) {
+		int i = str.indexOf(' ');
+		return i != -1 ? str.substring(0, i) : str;
+	}
+
+	private static String getFullName(EntryTree<EntryMapping> mappings, Entry<?> entry) {
+		String name = mappings.get(entry).getTargetName();
+
+		if (entry.getParent() != null) {
+			name = getFullName(mappings, entry.getParent()) + '.' + name;
+		}
+
+		return name;
+	}
+}

--- a/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
+++ b/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
@@ -23,8 +23,7 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 public class JavadocLintTask extends DefaultTask {
-	private static final Pattern PARAM_DOC_START = Pattern.compile("^@param\\s+");
-	private static final Pattern TYPE_PARAM_DOC_START = Pattern.compile("^@param\\s+<");
+	private static final Pattern PARAM_DOC_LINE = Pattern.compile("^@param\\s+[^<].*$");
 	private final DirectoryProperty mappingDirectory = getProject().getObjects().directoryProperty();
 
 	@InputDirectory
@@ -66,7 +65,7 @@ public class JavadocLintTask extends DefaultTask {
 					}
 				} else if (entry instanceof MethodEntry) {
 					if (javadoc.lines().anyMatch(JavadocLintTask::isRegularMethodParameter)) {
-						localErrors.add("method contains parameter docs, which should be on the parameter itself");
+						localErrors.add("method javadoc contains parameter docs, which should be on the parameter itself");
 					}
 				}
 
@@ -92,7 +91,7 @@ public class JavadocLintTask extends DefaultTask {
 	}
 
 	private static boolean isRegularMethodParameter(String line) {
-		return PARAM_DOC_START.matcher(line).matches() && !TYPE_PARAM_DOC_START.matcher(line).matches();
+		return PARAM_DOC_LINE.matcher(line).matches();
 	}
 
 	private static String getFirstWord(String str) {

--- a/src/test/java/net/fabricmc/filament/test/JavadocLintTest.java
+++ b/src/test/java/net/fabricmc/filament/test/JavadocLintTest.java
@@ -1,0 +1,65 @@
+package net.fabricmc.filament.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+
+class JavadocLintTest extends ProjectTest {
+	@Test
+	public void paramInMethod() {
+		setupProject("javadocLint", "mappings/ParamInMethod.mapping");
+
+		BuildResult result = GradleRunner.create()
+				.withPluginClasspath()
+				.withProjectDir(projectDirectory)
+				.withArguments("javadocLint")
+				.buildAndFail();
+
+		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+		assertThat(result.getOutput()).contains("method javadoc contains parameter docs");
+	}
+
+	@Test
+	public void periodInParam() {
+		setupProject("javadocLint", "mappings/ParamPeriod.mapping");
+
+		BuildResult result = GradleRunner.create()
+				.withPluginClasspath()
+				.withProjectDir(projectDirectory)
+				.withArguments("javadocLint")
+				.buildAndFail();
+
+		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+		assertThat(result.getOutput()).contains("parameter javadoc ends with '.'");
+	}
+
+	@Test
+	public void uppercaseParam() {
+		setupProject("javadocLint", "mappings/UppercaseParam.mapping");
+
+		BuildResult result = GradleRunner.create()
+				.withPluginClasspath()
+				.withProjectDir(projectDirectory)
+				.withArguments("javadocLint")
+				.buildAndFail();
+
+		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+		assertThat(result.getOutput()).contains("parameter javadoc starts with uppercase word 'The'");
+	}
+
+	@Test
+	public void successful() {
+		setupProject("javadocLint", "mappings/Successful.mapping");
+
+		BuildResult result = GradleRunner.create()
+				.withPluginClasspath()
+				.withProjectDir(projectDirectory)
+				.withArguments("javadocLint")
+				.build();
+
+		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+	}
+}

--- a/src/test/java/net/fabricmc/filament/test/JavadocLintTest.java
+++ b/src/test/java/net/fabricmc/filament/test/JavadocLintTest.java
@@ -8,15 +8,19 @@ import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
 
 class JavadocLintTest extends ProjectTest {
+	private BuildResult runGradleBuild(boolean shouldSucceed) {
+		GradleRunner runner = GradleRunner.create()
+				.withPluginClasspath()
+				.withProjectDir(projectDirectory)
+				.withArguments("javadocLint");
+
+		return shouldSucceed ? runner.build() : runner.buildAndFail();
+	}
+
 	@Test
 	public void paramInMethod() {
 		setupProject("javadocLint", "mappings/ParamInMethod.mapping");
-
-		BuildResult result = GradleRunner.create()
-				.withPluginClasspath()
-				.withProjectDir(projectDirectory)
-				.withArguments("javadocLint")
-				.buildAndFail();
+		BuildResult result = runGradleBuild(false);
 
 		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 		assertThat(result.getOutput()).contains("method javadoc contains parameter docs");
@@ -25,12 +29,7 @@ class JavadocLintTest extends ProjectTest {
 	@Test
 	public void periodInParam() {
 		setupProject("javadocLint", "mappings/ParamPeriod.mapping");
-
-		BuildResult result = GradleRunner.create()
-				.withPluginClasspath()
-				.withProjectDir(projectDirectory)
-				.withArguments("javadocLint")
-				.buildAndFail();
+		BuildResult result = runGradleBuild(false);
 
 		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 		assertThat(result.getOutput()).contains("parameter javadoc ends with '.'");
@@ -39,12 +38,7 @@ class JavadocLintTest extends ProjectTest {
 	@Test
 	public void uppercaseParam() {
 		setupProject("javadocLint", "mappings/UppercaseParam.mapping");
-
-		BuildResult result = GradleRunner.create()
-				.withPluginClasspath()
-				.withProjectDir(projectDirectory)
-				.withArguments("javadocLint")
-				.buildAndFail();
+		BuildResult result = runGradleBuild(false);
 
 		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 		assertThat(result.getOutput()).contains("parameter javadoc starts with uppercase word 'The'");
@@ -58,12 +52,7 @@ class JavadocLintTest extends ProjectTest {
 				"mappings/ParamPeriod.mapping",
 				"mappings/UppercaseParam.mapping"
 		);
-
-		BuildResult result = GradleRunner.create()
-				.withPluginClasspath()
-				.withProjectDir(projectDirectory)
-				.withArguments("javadocLint")
-				.buildAndFail();
+		BuildResult result = runGradleBuild(false);
 
 		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
 		assertThat(result.getOutput()).contains("Found 3 javadoc format errors");
@@ -72,12 +61,7 @@ class JavadocLintTest extends ProjectTest {
 	@Test
 	public void successful() {
 		setupProject("javadocLint", "mappings/Successful.mapping");
-
-		BuildResult result = GradleRunner.create()
-				.withPluginClasspath()
-				.withProjectDir(projectDirectory)
-				.withArguments("javadocLint")
-				.build();
+		BuildResult result = runGradleBuild(true);
 
 		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
 	}

--- a/src/test/java/net/fabricmc/filament/test/JavadocLintTest.java
+++ b/src/test/java/net/fabricmc/filament/test/JavadocLintTest.java
@@ -51,6 +51,25 @@ class JavadocLintTest extends ProjectTest {
 	}
 
 	@Test
+	public void multipleErrors() {
+		setupProject(
+				"javadocLint",
+				"mappings/ParamInMethod.mapping",
+				"mappings/ParamPeriod.mapping",
+				"mappings/UppercaseParam.mapping"
+		);
+
+		BuildResult result = GradleRunner.create()
+				.withPluginClasspath()
+				.withProjectDir(projectDirectory)
+				.withArguments("javadocLint")
+				.buildAndFail();
+
+		assertThat(result.task(":javadocLint").getOutcome()).isEqualTo(TaskOutcome.FAILED);
+		assertThat(result.getOutput()).contains("Found 3 javadoc format errors");
+	}
+
+	@Test
 	public void successful() {
 		setupProject("javadocLint", "mappings/Successful.mapping");
 

--- a/src/test/java/net/fabricmc/filament/test/ProjectTest.java
+++ b/src/test/java/net/fabricmc/filament/test/ProjectTest.java
@@ -1,0 +1,36 @@
+package net.fabricmc.filament.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.io.TempDir;
+
+abstract class ProjectTest {
+	@TempDir
+	protected File projectDirectory;
+
+	protected final void setupProject(String name, String... extraFiles) {
+		try {
+			copyProjectFile(name, "build.gradle");
+			copyProjectFile(name, "settings.gradle");
+
+			for (String file : extraFiles) {
+				copyProjectFile(name, file);
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not set up test for project " + name, e);
+		}
+	}
+
+	private void copyProjectFile(String projectName, String file) throws IOException {
+		try (InputStream in = ProjectTest.class.getResourceAsStream("/projects/" + projectName + '/' + file)) {
+			Path target = projectDirectory.toPath().resolve(file);
+			Files.createDirectories(target.getParent());
+			Files.copy(in, target);
+		}
+	}
+}

--- a/src/test/resources/projects/javadocLint/build.gradle
+++ b/src/test/resources/projects/javadocLint/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+	id 'net.fabricmc.filament'
+}
+
+javadocLint {
+	mappingDirectory = file('mappings')
+}

--- a/src/test/resources/projects/javadocLint/mappings/ParamInMethod.mapping
+++ b/src/test/resources/projects/javadocLint/mappings/ParamInMethod.mapping
@@ -1,0 +1,4 @@
+CLASS a com/example/ParamInMethod
+	METHOD a something (Ljava/lang/String;)V
+		COMMENT @param name the name
+		ARG 1 name

--- a/src/test/resources/projects/javadocLint/mappings/ParamPeriod.mapping
+++ b/src/test/resources/projects/javadocLint/mappings/ParamPeriod.mapping
@@ -1,0 +1,4 @@
+CLASS b com/example/ParamPeriod
+	METHOD a something (Ljava/lang/String;)V
+		ARG 1 name
+			COMMENT the name.

--- a/src/test/resources/projects/javadocLint/mappings/Successful.mapping
+++ b/src/test/resources/projects/javadocLint/mappings/Successful.mapping
@@ -1,0 +1,6 @@
+CLASS d com/example/Successful
+	METHOD a something (Ljava/lang/String;)V
+		COMMENT This is a method that does something.
+		COMMENT @param <T> an unused type
+		ARG 1 name
+			COMMENT the name

--- a/src/test/resources/projects/javadocLint/mappings/UppercaseParam.mapping
+++ b/src/test/resources/projects/javadocLint/mappings/UppercaseParam.mapping
@@ -1,0 +1,4 @@
+CLASS c com/example/UppercaseParam
+	METHOD a something (Ljava/lang/String;)V
+		ARG 1 name
+			COMMENT The name

--- a/src/test/resources/projects/javadocLint/settings.gradle
+++ b/src/test/resources/projects/javadocLint/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		mavenCentral()
+		maven {
+			name = "FabricMC"
+			url = "https://maven.fabricmc.net"
+		}
+	}
+}


### PR DESCRIPTION
Supersedes FabricMC/yarn#2289. (There will also be a PR to Yarn hooking this up if this is merged)

- Adds a `javadocLint` task that ensures the current javadoc comments follow Yarn's guidelines for javadocs, namely:

  > Write quick descriptions for parameter javadocs as well as `@return` tags, with no uppercase or period. Add parameter docs to the parameter itself instead of using the `@param` tag.

  (The `@return` tags are not currently checked, nor are some other guidelines defined in `CONVENTIONS.md`. The parameter style seems to be broken most often.)

- `JavadocLintTask` only processes mapping files. It allows centralising the linting (you'd need to check mappings anyway for the method `@param` checker) as well as giving more informative error messages than eg. Checkstyle.
- Open question: Should the task support setting the rules in the task configuration instead of hardcoding Yarn's rules here in Filament? (Shouldn't be too hard to change)

<details><summary>Example output of <code>javadocLint</code> when there are errors:</summary>
<pre>
lint: net/minecraft/world/gen/chunk/ChunkGenerator.locateStructure.radius: parameter javadoc ends with '.'
lint: net/minecraft/world/gen/chunk/ChunkGenerator.locateStructure.radius: parameter javadoc starts with uppercase word 'The'
lint: net/minecraft/entity/player/PlayerEntity.dropItem.throwRandomly: parameter javadoc starts with uppercase word 'If'
lint: net/minecraft/entity/EyeOfEnderEntity.initTargetPos: method contains parameter docs, which should be on the parameter itself
lint: net/minecraft/screen/ScreenHandler.onSlotClick.actionType: parameter javadoc starts with uppercase word 'The'
</pre>
</details>