### PR TITLE
Use newer Enigma API to avoid copying files into temp dirs

### DIFF
--- a/src/main/java/net/fabricmc/filament/util/FileUtil.java
+++ b/src/main/java/net/fabricmc/filament/util/FileUtil.java
@@ -4,9 +4,23 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class FileUtil {
 	private FileUtil() {
+	}
+
+	public static Set<Path> toPaths(Iterable<File> files) {
+		Set<Path> set = files instanceof Collection<File> c ? new HashSet<>(c.size()) : new HashSet<>();
+
+		for (File file : files) {
+			set.add(file.toPath());
+		}
+
+		return set;
 	}
 
 	public static void deleteDirectory(File directory) throws IOException {


### PR DESCRIPTION
Also appends the method descriptor to lint errors now in `getFullName`.