### PR TITLE
Don't use WorkQueue.await

### DIFF
--- a/src/main/java/net/fabricmc/filament/task/CombineUnpickDefinitionsTask.java
+++ b/src/main/java/net/fabricmc/filament/task/CombineUnpickDefinitionsTask.java
@@ -43,7 +43,6 @@ public abstract class CombineUnpickDefinitionsTask extends DefaultTask {
 			parameters.getInput().set(getInput());
 			parameters.getOutput().set(getOutput());
 		});
-		workQueue.await();
 	}
 
 	public interface CombineParameters extends WorkParameters {

--- a/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
+++ b/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
@@ -65,8 +65,6 @@ public abstract class JavadocLintTask extends DefaultTask {
 				}
 			}
 		});
-
-		workQueue.await();
 	}
 
 	private static boolean isRegularMethodParameter(String line) {

--- a/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
+++ b/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
@@ -65,7 +65,6 @@ public abstract class RemapUnpickDefinitionsTask extends DefaultTask {
 			parameters.getTargetNamespace().set(getTargetNamespace());
 			parameters.getOutput().set(getOutput());
 		});
-		workQueue.await();
 	}
 
 	public interface RemapParameters extends WorkParameters {


### PR DESCRIPTION
I'm pretty sure it actually prevents parallel exec, and it's not used by the [Gradle docs](https://docs.gradle.org/current/userguide/worker_api.html) either.